### PR TITLE
Cgm 1360 rgbd old scan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,9 @@ venv.bak/
 
 # os
 .DS_Store
+
+
+../.amlignore
+../.amlignore.amltmp
+.amlignore
+.amlignore.amltmp

--- a/src/result_gen_with_api.py
+++ b/src/result_gen_with_api.py
@@ -268,40 +268,40 @@ def main():
 
     result_generation = ResultGeneration(cgm_api, workflow, scan_metadata, scan_parent_dir)
 
-    flow = BlurFlow(
-        result_generation,
-        blur_workflow_path,
-        rgb_artifacts,
-        scan_version)
-    flows.append(flow)
+    # flow = BlurFlow(
+    #     result_generation,
+    #     blur_workflow_path,
+    #     rgb_artifacts,
+    #     scan_version)
+    # flows.append(flow)
 
-    flow = StandingLaying(
-        result_generation,
-        standing_laying_workflow_path,
-        rgb_artifacts)
-    flows.append(flow)
+    # flow = StandingLaying(
+    #     result_generation,
+    #     standing_laying_workflow_path,
+    #     rgb_artifacts)
+    # flows.append(flow)
 
-    flow = DepthMapImgFlow(
-        result_generation,
-        depthmap_img_workflow_path,
-        depth_artifacts)
-    flows.append(flow)
+    # flow = DepthMapImgFlow(
+    #     result_generation,
+    #     depthmap_img_workflow_path,
+    #     depth_artifacts)
+    # flows.append(flow)
 
-    flow = HeightFlowPlainCnn(
-        result_generation,
-        height_workflow_artifact_path,
-        height_workflow_scan_path,
-        depth_artifacts,
-        person_details)
-    flows.append(flow)
+    # flow = HeightFlowPlainCnn(
+    #     result_generation,
+    #     height_workflow_artifact_path,
+    #     height_workflow_scan_path,
+    #     depth_artifacts,
+    #     person_details)
+    # flows.append(flow)
 
-    flow = HeightFlowMultiArtifact(
-        result_generation,
-        height_workflow_artifact_path,
-        height_depthmapmultiartifactlatefusion_workflow_path,
-        depth_artifacts,
-        person_details)
-    flows.append(flow)
+    # flow = HeightFlowMultiArtifact(
+    #     result_generation,
+    #     height_workflow_artifact_path,
+    #     height_depthmapmultiartifactlatefusion_workflow_path,
+    #     depth_artifacts,
+    #     person_details)
+    # flows.append(flow)
 
     # flow = HeightFlowDeepEnsemble(
     #     result_generation,
@@ -311,13 +311,13 @@ def main():
     #     person_details)
     # flows.append(flow)
 
-    flow = WeightFlow(
-        result_generation,
-        weight_workflow_artifact_path,
-        weight_workflow_scan_path,
-        depth_artifacts,
-        person_details)
-    flows.append(flow)
+    # flow = WeightFlow(
+    #     result_generation,
+    #     weight_workflow_artifact_path,
+    #     weight_workflow_scan_path,
+    #     depth_artifacts,
+    #     person_details)
+    # flows.append(flow)
 
     flow = HeightFlowRGBD(
             result_generation,

--- a/src/result_gen_with_api.py
+++ b/src/result_gen_with_api.py
@@ -320,12 +320,12 @@ def main():
     flows.append(flow)
 
     flow = HeightFlowRGBD(
-            result_generation,
-            height_rgbd_workflow_artifact_path,
-            height_rgbd_workflow_scan_path,
-            depth_artifacts,
-            person_details,
-            rgb_artifacts)
+        result_generation,
+        height_rgbd_workflow_artifact_path,
+        height_rgbd_workflow_scan_path,
+        depth_artifacts,
+        person_details,
+        rgb_artifacts)
     flows.append(flow)
 
     for flow in flows:

--- a/src/result_gen_with_api.py
+++ b/src/result_gen_with_api.py
@@ -268,40 +268,40 @@ def main():
 
     result_generation = ResultGeneration(cgm_api, workflow, scan_metadata, scan_parent_dir)
 
-    # flow = BlurFlow(
-    #     result_generation,
-    #     blur_workflow_path,
-    #     rgb_artifacts,
-    #     scan_version)
-    # flows.append(flow)
+    flow = BlurFlow(
+        result_generation,
+        blur_workflow_path,
+        rgb_artifacts,
+        scan_version)
+    flows.append(flow)
 
-    # flow = StandingLaying(
-    #     result_generation,
-    #     standing_laying_workflow_path,
-    #     rgb_artifacts)
-    # flows.append(flow)
+    flow = StandingLaying(
+        result_generation,
+        standing_laying_workflow_path,
+        rgb_artifacts)
+    flows.append(flow)
 
-    # flow = DepthMapImgFlow(
-    #     result_generation,
-    #     depthmap_img_workflow_path,
-    #     depth_artifacts)
-    # flows.append(flow)
+    flow = DepthMapImgFlow(
+        result_generation,
+        depthmap_img_workflow_path,
+        depth_artifacts)
+    flows.append(flow)
 
-    # flow = HeightFlowPlainCnn(
-    #     result_generation,
-    #     height_workflow_artifact_path,
-    #     height_workflow_scan_path,
-    #     depth_artifacts,
-    #     person_details)
-    # flows.append(flow)
+    flow = HeightFlowPlainCnn(
+        result_generation,
+        height_workflow_artifact_path,
+        height_workflow_scan_path,
+        depth_artifacts,
+        person_details)
+    flows.append(flow)
 
-    # flow = HeightFlowMultiArtifact(
-    #     result_generation,
-    #     height_workflow_artifact_path,
-    #     height_depthmapmultiartifactlatefusion_workflow_path,
-    #     depth_artifacts,
-    #     person_details)
-    # flows.append(flow)
+    flow = HeightFlowMultiArtifact(
+        result_generation,
+        height_workflow_artifact_path,
+        height_depthmapmultiartifactlatefusion_workflow_path,
+        depth_artifacts,
+        person_details)
+    flows.append(flow)
 
     # flow = HeightFlowDeepEnsemble(
     #     result_generation,
@@ -311,13 +311,13 @@ def main():
     #     person_details)
     # flows.append(flow)
 
-    # flow = WeightFlow(
-    #     result_generation,
-    #     weight_workflow_artifact_path,
-    #     weight_workflow_scan_path,
-    #     depth_artifacts,
-    #     person_details)
-    # flows.append(flow)
+    flow = WeightFlow(
+        result_generation,
+        weight_workflow_artifact_path,
+        weight_workflow_scan_path,
+        depth_artifacts,
+        person_details)
+    flows.append(flow)
 
     flow = HeightFlowRGBD(
             result_generation,

--- a/src/result_gen_with_api.py
+++ b/src/result_gen_with_api.py
@@ -14,6 +14,7 @@ from result_generation.height.height_multiartifact import HeightFlowMultiArtifac
 # from result_generation.height.height_ensemble import HeightFlowDeepEnsemble
 from result_generation.standing import StandingLaying
 from result_generation.weight import WeightFlow
+from result_generation.height.height_rgbd import HeightFlowRGBD
 
 
 class ProcessWorkflows:
@@ -215,6 +216,8 @@ def parse_args():
     # parser.add_argument('--height_ensemble_workflow_scan_path', default="/app/src/workflows/height-ensemble-workflow-scan.json")  # noqa: E501
     parser.add_argument('--weight_workflow_artifact_path', default=f"{workflow_dir}/weight-workflow-artifact.json")  # noqa: E501
     parser.add_argument('--weight_workflow_scan_path', default=f"{workflow_dir}/weight-workflow-scan.json")  # noqa: E501
+    parser.add_argument('--height_rgbd_workflow_artifact_path', default=f"{workflow_dir}/height-rgbd-workflow-artifact.json")  # noqa: E501
+    parser.add_argument('--height_rgbd_workflow_scan_path', default=f"{workflow_dir}/height-rgbd-workflow-scan.json")  # noqa: E501
     args = parser.parse_args()
     return args
 
@@ -232,6 +235,8 @@ def main():
     height_depthmapmultiartifactlatefusion_workflow_path = args.height_depthmapmultiartifactlatefusion_workflow_path
     weight_workflow_artifact_path = args.weight_workflow_artifact_path
     weight_workflow_scan_path = args.weight_workflow_scan_path
+    height_rgbd_workflow_artifact_path = args.height_rgbd_workflow_artifact_path
+    height_rgbd_workflow_scan_path = args.height_rgbd_workflow_scan_path
 
     scan_metadata_name = 'scan_meta_' + str(uuid.uuid4()) + '.json'
     scan_metadata_path = os.path.join(scan_parent_dir, scan_metadata_name)
@@ -312,6 +317,15 @@ def main():
         weight_workflow_scan_path,
         depth_artifacts,
         person_details)
+    flows.append(flow)
+
+    flow = HeightFlowRGBD(
+            result_generation,
+            height_rgbd_workflow_artifact_path,
+            height_rgbd_workflow_scan_path,
+            depth_artifacts,
+            person_details,
+            rgb_artifacts)
     flows.append(flow)
 
     for flow in flows:

--- a/src/result_generation/height/height_rgbd.py
+++ b/src/result_generation/height/height_rgbd.py
@@ -30,34 +30,36 @@ class HeightFlowRGBD(HeightFlow):
             self.result_generation.scan_metadata['id'],
             'img')
         image_order_ids = []
-        order_ids=[image_order_ids.append(artifact['order']) for artifact in self.image_artifacts]
+        for image_artifacts in self.image_artifacts:
+            image_order_ids.append(image_artifacts['order']
+
         for artifact in self.artifacts:
-            input_path = self.result_generation.get_input_path(
+            input_path=self.result_generation.get_input_path(
                 self.scan_directory, artifact['file'])
-            depth_order = artifact['order']
-            closest_order_id = preprocessing.find_corresponding_image(image_order_ids,depth_order)
+            depth_order=artifact['order']
+            closest_order_id=preprocessing.find_corresponding_image(image_order_ids, depth_order)
 
             # closest_order_id = min(image_order_ids, key=lambda order:abs(order-img_id))
-            result_image_dict = next(
+            result_image_dict=next(
                 iter(item for item in self.image_artifacts if item['order'] == closest_order_id), None)
             if result_image_dict:
-                image_input_path = self.result_generation.get_input_path(
+                image_input_path=self.result_generation.get_input_path(
                     scan_image_directory, result_image_dict['file'])
             else:
-                print("No RGB found for order:", img_id)
+                print("No RGB found for order:", depth_order)
                 continue
-            raw_image = cv2.imread(str(image_input_path))  # cv2.imread gives error when reading from posix path
-            rot_image = cv2.rotate(raw_image, cv2.ROTATE_90_CLOCKWISE)
-            image = preprocessing.preprocess_image(rot_image)
-            data, width, height, depth_scale, _max_confidence = preprocessing.load_depth(
+            raw_image=cv2.imread(str(image_input_path))  # cv2.imread gives error when reading from posix path
+            rot_image=cv2.rotate(raw_image, cv2.ROTATE_90_CLOCKWISE)
+            image=preprocessing.preprocess_image(rot_image)
+            data, width, height, depth_scale, _max_confidence=preprocessing.load_depth(
                 input_path)
-            depthmap = preprocessing.prepare_depthmap(
+            depthmap=preprocessing.prepare_depthmap(
                 data, width, height, depth_scale)
-            depthmap = preprocessing.preprocess(depthmap)
-            rgbd_data = tf.concat([image, depthmap], axis=2)
-            rgbd_data = tf.image.resize(
+            depthmap=preprocessing.preprocess(depthmap)
+            rgbd_data=tf.concat([image, depthmap], axis=2)
+            rgbd_data=tf.image.resize(
                 rgbd_data, (preprocessing.IMAGE_TARGET_HEIGHT,
                             preprocessing.IMAGE_TARGET_WIDTH))
             rgbd_scan.append(rgbd_data)
-        rgbd_scan = np.array(rgbd_scan)
+        rgbd_scan=np.array(rgbd_scan)
         return rgbd_scan

--- a/src/result_generation/height/height_rgbd.py
+++ b/src/result_generation/height/height_rgbd.py
@@ -14,7 +14,7 @@ sys.path.append(str(Path(__file__).parents[1]))
 import utils.inference as inference  # noqa: E402
 import utils.preprocessing as preprocessing  # noqa: E402
 
-ORDER_DIFFERENCE_ALLOWED =3 
+ORDER_DIFFERENCE_ALLOWED = 3
 
 
 class HeightFlowRGBD(HeightFlow):
@@ -30,15 +30,18 @@ class HeightFlowRGBD(HeightFlow):
             self.result_generation.scan_parent_dir,
             self.result_generation.scan_metadata['id'],
             'img')
+
         image_order_ids = []
-        order_ids=[image_order_ids.append(artifact['order']) for artifact in self.image_artifacts]
+        for image_artifact in self.image_artifacts:
+            image_order_ids.append(image_artifact['order'])
+
+        print("image order_idss", image_order_ids)
         for artifact in self.artifacts:
             input_path = self.result_generation.get_input_path(
                 self.scan_directory, artifact['file'])
             depth_id = artifact['order']
-            closest_order_id = preprocessing.find_corresponding_image(image_order_ids,depth_id)
-            print("closest order:",closest_order_id)
-            if abs(closest_order_id-depth_id) >= ORDER_DIFFERENCE_ALLOWED:
+            closest_order_id = preprocessing.find_corresponding_image(image_order_ids, depth_id)
+            if abs(closest_order_id - depth_id) >= ORDER_DIFFERENCE_ALLOWED:
                 logging.info("No corresponding image artifact found for the depthmap")
                 continue
             # closest_order_id = min(image_order_ids, key=lambda order:abs(order-img_id))
@@ -48,7 +51,7 @@ class HeightFlowRGBD(HeightFlow):
                 image_input_path = self.result_generation.get_input_path(
                     scan_image_directory, result_image_dict['file'])
             else:
-                logging.info("No RGB found for order:", img_id)
+                logging.info("No RGB found for order:", depth_id)
                 continue
             image = cv2.imread(str(image_input_path))  # cv2.imread gives error when reading from posix path
             image = preprocessing.preprocess_image(image)

--- a/src/result_generation/height/height_rgbd.py
+++ b/src/result_generation/height/height_rgbd.py
@@ -1,4 +1,5 @@
 import sys
+import logging
 from datetime import datetime
 from pathlib import Path
 import cv2
@@ -12,6 +13,8 @@ from result_generation.height.height import HeightFlow
 sys.path.append(str(Path(__file__).parents[1]))
 import utils.inference as inference  # noqa: E402
 import utils.preprocessing as preprocessing  # noqa: E402
+
+ORDER_DIFFERENCE_ALLOWED =3 
 
 
 class HeightFlowRGBD(HeightFlow):
@@ -27,17 +30,25 @@ class HeightFlowRGBD(HeightFlow):
             self.result_generation.scan_parent_dir,
             self.result_generation.scan_metadata['id'],
             'img')
+        image_order_ids = []
+        order_ids=[image_order_ids.append(artifact['order']) for artifact in self.image_artifacts]
         for artifact in self.artifacts:
             input_path = self.result_generation.get_input_path(
                 self.scan_directory, artifact['file'])
-            img_id = artifact['order']
+            depth_id = artifact['order']
+            closest_order_id = preprocessing.find_corresponding_image(image_order_ids,depth_id)
+            print("closest order:",closest_order_id)
+            if abs(closest_order_id-depth_id) >= ORDER_DIFFERENCE_ALLOWED:
+                logging.info("No corresponding image artifact found for the depthmap")
+                continue
+            # closest_order_id = min(image_order_ids, key=lambda order:abs(order-img_id))
             result_image_dict = next(
-                iter(item for item in self.image_artifacts if item['order'] == img_id), None)
+                iter(item for item in self.image_artifacts if item['order'] == closest_order_id), None)
             if result_image_dict:
                 image_input_path = self.result_generation.get_input_path(
                     scan_image_directory, result_image_dict['file'])
             else:
-                print("No RGB found for order:", img_id)
+                logging.info("No RGB found for order:", img_id)
                 continue
             image = cv2.imread(str(image_input_path))  # cv2.imread gives error when reading from posix path
             image = preprocessing.preprocess_image(image)

--- a/src/result_generation/height/height_rgbd.py
+++ b/src/result_generation/height/height_rgbd.py
@@ -1,4 +1,5 @@
 import sys
+import logging
 from datetime import datetime
 from pathlib import Path
 import cv2
@@ -13,7 +14,7 @@ sys.path.append(str(Path(__file__).parents[1]))
 import utils.inference as inference  # noqa: E402
 import utils.preprocessing as preprocessing  # noqa: E402
 
-CLOSEST_IMAGE_ORDER = 3
+ORDER_DIFFERENCE_ALLOWED = 3
 
 
 class HeightFlowRGBD(HeightFlow):
@@ -29,37 +30,39 @@ class HeightFlowRGBD(HeightFlow):
             self.result_generation.scan_parent_dir,
             self.result_generation.scan_metadata['id'],
             'img')
+
         image_order_ids = []
-        for image_artifacts in self.image_artifacts:
-            image_order_ids.append(image_artifacts['order']
+        for image_artifact in self.image_artifacts:
+            image_order_ids.append(image_artifact['order'])
 
         for artifact in self.artifacts:
-            input_path=self.result_generation.get_input_path(
+            input_path = self.result_generation.get_input_path(
                 self.scan_directory, artifact['file'])
-            depth_order=artifact['order']
-            closest_order_id=preprocessing.find_corresponding_image(image_order_ids, depth_order)
-
-            # closest_order_id = min(image_order_ids, key=lambda order:abs(order-img_id))
-            result_image_dict=next(
+            depth_id = artifact['order']
+            closest_order_id = preprocessing.find_corresponding_image(image_order_ids, depth_id)
+            if abs(closest_order_id - depth_id) >= ORDER_DIFFERENCE_ALLOWED:
+                logging.info("No corresponding image artifact found for the depthmap")
+                continue
+            result_image_dict = next(
                 iter(item for item in self.image_artifacts if item['order'] == closest_order_id), None)
             if result_image_dict:
-                image_input_path=self.result_generation.get_input_path(
+                image_input_path = self.result_generation.get_input_path(
                     scan_image_directory, result_image_dict['file'])
             else:
-                print("No RGB found for order:", depth_order)
+                logging.info("No RGB found for order:", depth_id)
                 continue
-            raw_image=cv2.imread(str(image_input_path))  # cv2.imread gives error when reading from posix path
-            rot_image=cv2.rotate(raw_image, cv2.ROTATE_90_CLOCKWISE)
-            image=preprocessing.preprocess_image(rot_image)
-            data, width, height, depth_scale, _max_confidence=preprocessing.load_depth(
+            raw_image = cv2.imread(str(image_input_path))  # cv2.imread gives error when reading from posix path
+            rot_image = cv2.rotate(raw_image, cv2.ROTATE_90_CLOCKWISE)
+            image = preprocessing.preprocess_image(rot_image)
+            data, width, height, depth_scale, _max_confidence = preprocessing.load_depth(
                 input_path)
-            depthmap=preprocessing.prepare_depthmap(
+            depthmap = preprocessing.prepare_depthmap(
                 data, width, height, depth_scale)
-            depthmap=preprocessing.preprocess(depthmap)
-            rgbd_data=tf.concat([image, depthmap], axis=2)
-            rgbd_data=tf.image.resize(
+            depthmap = preprocessing.preprocess(depthmap)
+            rgbd_data = tf.concat([image, depthmap], axis=2)
+            rgbd_data = tf.image.resize(
                 rgbd_data, (preprocessing.IMAGE_TARGET_HEIGHT,
                             preprocessing.IMAGE_TARGET_WIDTH))
             rgbd_scan.append(rgbd_data)
-        rgbd_scan=np.array(rgbd_scan)
+        rgbd_scan = np.array(rgbd_scan)
         return rgbd_scan

--- a/src/utils/preprocessing.py
+++ b/src/utils/preprocessing.py
@@ -129,3 +129,10 @@ def sample_systematic_from_artifacts(artifacts: list, n_artifacts: int) -> list:
     selected_artifacts = [artifacts[i] for i in indexes_to_select]
     assert len(selected_artifacts) == n_artifacts, str(artifacts)
     return selected_artifacts
+
+def find_corresponding_image(image_order_ids,depth_id):
+    """
+    Code to find corresponding image for the given depthmap on the basis of order
+    """
+    closest_order_id = min(image_order_ids, key=lambda order:abs(order-depth_id))
+    return closest_order_id

--- a/src/utils/preprocessing.py
+++ b/src/utils/preprocessing.py
@@ -130,9 +130,10 @@ def sample_systematic_from_artifacts(artifacts: list, n_artifacts: int) -> list:
     assert len(selected_artifacts) == n_artifacts, str(artifacts)
     return selected_artifacts
 
-def find_corresponding_image(image_order_ids,depth_id):
+
+def find_corresponding_image(image_order_ids, depth_id):
     """
     Code to find corresponding image for the given depthmap on the basis of order
     """
-    closest_order_id = min(image_order_ids, key=lambda order:abs(order-depth_id))
+    closest_order_id = min(image_order_ids, key=lambda order: abs(order - depth_id))
     return closest_order_id


### PR DESCRIPTION
RGBD  workflow is now compliant with  v0.8 and in the new tenant.
US#1360( https://dev.azure.com/cgmorg/ChildGrowthMonitor/_workitems/edit/1360)

Test:
It's been tested on a v0.8 scan. For further testing, we need to make it work through testing in a sandbox environment.