### PR TITLE
Improve depthmap visualisation

### DIFF
--- a/src/result_generation/depthmap_image.py
+++ b/src/result_generation/depthmap_image.py
@@ -41,7 +41,7 @@ class DepthMapImgFlow:
         data, width, height, depth_scale, _max_confidence = preprocessing.load_depth(input_path)
 
         depthmap = preprocessing.prepare_depthmap(data, width, height, depth_scale)
-        depthmap  = depthmap /2.0
+        depthmap = depthmap / 2.0
 
         # depthmap = preprocessing.preprocess(depthmap)
         # depthmap = depthmap.reshape((depthmap.shape[0], depthmap.shape[1], 1))

--- a/src/result_generation/depthmap_image.py
+++ b/src/result_generation/depthmap_image.py
@@ -41,6 +41,7 @@ class DepthMapImgFlow:
         data, width, height, depth_scale, _max_confidence = preprocessing.load_depth(input_path)
 
         depthmap = preprocessing.prepare_depthmap(data, width, height, depth_scale)
+        depthmap  = depthmap /2.0
 
         # depthmap = preprocessing.preprocess(depthmap)
         # depthmap = depthmap.reshape((depthmap.shape[0], depthmap.shape[1], 1))

--- a/src/workflows/depthmap-img-workflow.json
+++ b/src/workflows/depthmap-img-workflow.json
@@ -1,6 +1,6 @@
 {
     "name": "depthmap-image",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "result_format": "img",
     "result_binding": "artifact",
     "data":{


### PR DESCRIPTION
Component Requirements 1319: Depthmaps in tagging tool is not clear

This PR is to imrpove the depthmap visualisation in the tagging tool.

Visualisation before Change:

![depthmap_before](https://user-images.githubusercontent.com/24511086/127168875-d7014534-ff2a-4995-8715-2fab94e918b0.png)

Visualisation After Change:

![Depthmap After](https://user-images.githubusercontent.com/24511086/127168906-8118fca5-ba24-47f8-af30-986ebce53b8d.png)
