### PR TITLE
Fix laying child orientation and face blur timing

### DIFF
--- a/src/result_gen_with_api.py
+++ b/src/result_gen_with_api.py
@@ -4,7 +4,6 @@ import json
 import os
 import uuid
 
-from matplotlib.pyplot import sca
 from azure.storage.queue import QueueService
 
 import log

--- a/src/result_gen_with_api.py
+++ b/src/result_gen_with_api.py
@@ -3,6 +3,8 @@ import base64
 import json
 import os
 import uuid
+
+from matplotlib.pyplot import sca
 from azure.storage.queue import QueueService
 
 import log
@@ -77,6 +79,7 @@ def run_normal_flow():
 
     scan_metadata = get_scan_metadata.get_scan_metadata()
     scan_version = scan_metadata['version']
+    scan_type = scan_metadata["type"]
     logger.info("%s %s", "Scan Type Version:", scan_version)
     workflow.get_list_of_worflows()
 
@@ -97,7 +100,8 @@ def run_normal_flow():
         blur_workflow_path,
         blur_faces_workflow_path,
         rgb_artifacts,
-        scan_version)
+        scan_version,
+        scan_type)
     flows.append(flow)
 
     flow = StandingLaying(
@@ -203,6 +207,7 @@ def run_retroactive_flow():
 
         scan_metadata = scan_metadata_with_workflow_obj['scans'][0]
         scan_version = scan_metadata['version']
+        scan_type = scan_metadata['type']
         logger.info("%s %s", "Scan Type Version:", scan_version)
 
         workflow_id = scan_metadata_with_workflow_obj['workflow_id']
@@ -227,7 +232,8 @@ def run_retroactive_flow():
                 blur_workflow_path,
                 blur_faces_workflow_path,
                 rgb_artifacts,
-                scan_version)
+                scan_version,
+                scan_type)
 
         elif workflow.match_workflows(standing_laying_workflow_path, workflow_id):
             logger.info("Matched with StandingLaying")

--- a/src/result_generation/blur.py
+++ b/src/result_generation/blur.py
@@ -23,6 +23,8 @@ resize_factor_for_scan_version = {
     "v1.0": 1,
 }
 
+standing_scan_type = ["101", "102", "103"]
+laying_scan_type = ["201", "202", "203"]
 
 class BlurFlow:
     """Face blur results generation"""
@@ -33,8 +35,9 @@ class BlurFlow:
             workflow_path,
             workflow_faces_path,
             artifacts,
-            scan_version):
-        store_attr('result_generation,artifacts,workflow_path,workflow_faces_path,artifacts,scan_version', self)
+            scan_version,
+            scan_type):
+        store_attr('result_generation,artifacts,workflow_path,workflow_faces_path,artifacts,scan_version,scan_type', self)
         self.workflow_obj = self.result_generation.workflows.load_workflows(self.workflow_path)
         self.workflow_faces_obj = self.result_generation.workflows.load_workflows(self.workflow_faces_path)
         if self.workflow_obj["data"]["input_format"] == 'image/jpeg':
@@ -79,7 +82,7 @@ class BlurFlow:
         logger.info("%s %s", "resize_factor is", self.resize_factor)
         logger.info("%s %s", "scan_version is", self.scan_version)
 
-    def blur_img_transformation_using_scan_version(self, rgb_image):
+    def blur_img_transformation_using_scan_version_and_scan_type(self, rgb_image):
         if self.scan_version in ["v0.7"]:
             # Make the image smaller, The limit of cgm-api to post an image is 500 KB.
             # Some of the images of v0.7 is greater than 500 KB
@@ -92,7 +95,11 @@ class BlurFlow:
         # if self.scan_version in ["v0.1", "v0.2", "v0.4", "v0.5", "v0.6", "v0.7", "v0.8", "v0.9", "v1.0"]:
         # The images are provided in 90degrees turned. Here we rotate 90degress to
         # the right.
-        image = cv2.rotate(image, cv2.ROTATE_90_CLOCKWISE)
+        if self.scan_type in standing_scan_type:
+            image = cv2.rotate(image, cv2.ROTATE_90_CLOCKWISE)
+        elif self.scan_type in laying_scan_type:
+            image = cv2.rotate(image, cv2.ROTATE_90_COUNTERCLOCKWISE)
+
         logger.info("%s %s", "scan_version is", self.scan_version)
         logger.info("swapped image axis")
         return image

--- a/src/result_generation/blur.py
+++ b/src/result_generation/blur.py
@@ -115,7 +115,7 @@ class BlurFlow:
         assert os.path.exists(source_path), f"{source_path} does not exist"
         rgb_image = cv2.imread(str(source_path))
 
-        image = self.blur_img_transformation_using_scan_version(rgb_image)
+        image = self.blur_img_transformation_using_scan_version_and_scan_type(rgb_image)
 
         # Scale image down for faster prediction.
         small_image = cv2.resize(

--- a/src/result_generation/blur.py
+++ b/src/result_generation/blur.py
@@ -26,6 +26,7 @@ resize_factor_for_scan_version = {
 standing_scan_type = ["101", "102", "103"]
 laying_scan_type = ["201", "202", "203"]
 
+
 class BlurFlow:
     """Face blur results generation"""
 

--- a/src/workflows/blur-workflow.json
+++ b/src/workflows/blur-workflow.json
@@ -1,6 +1,6 @@
 {
     "name": "face_recognition",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "result_format": "img",
     "result_binding": "artifact",
     "data":{

--- a/tests/set_up_dummy_objects.py
+++ b/tests/set_up_dummy_objects.py
@@ -22,7 +22,8 @@ def get_dummy_blur_flow_object(mock_some_fn):
         'src/workflows/blur-workflow.json',
         'src/workflows/blur-faces-worklows.json',
         sdv.rgb_artifacts,
-        sdv.scan_version)
+        sdv.scan_version,
+        sdv.scan_type)
 
 
 @patch.object(ProcessWorkflows, 'get_workflow_id')

--- a/tests/set_up_dummy_variables.py
+++ b/tests/set_up_dummy_variables.py
@@ -30,7 +30,7 @@ def create_dummy_vars():
         "scan_metadata_path": scan_metadata_path,
         "scan_metadata": scan_metadata,
         "scan_version": scan_metadata['version'],
-        "scan_type":scan_metadata['type'],
+        "scan_type": scan_metadata['type'],
         "rgb_artifacts": load_json(CWD.joinpath('tests', 'static_files', 'rgb_artifacts.json'))['rgb_artifacts'],
         "depth_artifacts": load_json(CWD.joinpath('tests', 'static_files', 'depth_artifacts.json'))['depth_artifacts'],
         "scan_parent_dir": CWD.joinpath('tests', 'static_files'),

--- a/tests/set_up_dummy_variables.py
+++ b/tests/set_up_dummy_variables.py
@@ -30,6 +30,7 @@ def create_dummy_vars():
         "scan_metadata_path": scan_metadata_path,
         "scan_metadata": scan_metadata,
         "scan_version": scan_metadata['version'],
+        "scan_type":scan_metadata['type'],
         "rgb_artifacts": load_json(CWD.joinpath('tests', 'static_files', 'rgb_artifacts.json'))['rgb_artifacts'],
         "depth_artifacts": load_json(CWD.joinpath('tests', 'static_files', 'depth_artifacts.json'))['depth_artifacts'],
         "scan_parent_dir": CWD.joinpath('tests', 'static_files'),

--- a/tests/test_blur_flow.py
+++ b/tests/test_blur_flow.py
@@ -21,8 +21,8 @@ def test_blur_face_file_exists():
     input_file = str(CWD.joinpath('tests', 'static_files', 'be1faf54-69c7-11eb-984b-a3ffd42e7b5a',
                      'img', 'bd8ba746-69c7-11eb-984b-23c55a7d518b'))
 
-    # Set Resize factor to be used in the blur_face
-    blurflow.blur_set_resize_factor()
+    # # Set Resize factor to be used in the blur_face
+    # blurflow.blur_set_resize_factor()
 
     # Exercise
     result = blurflow.blur_face(input_file)


### PR DESCRIPTION
Motivation:
The laying children orientation is not correct in the tagging tool. And Face blurring on laying children in not working properly.
The Face Blur is taking lot of time.

Solution:
Rotated the laying children and fixed the child orientation.
Tested on scan version : v1.0.2, v0.8, v0.9 which are only version present in inbmz environment for the laying children.

Face Blur is running on Image Size of Full Resolution. Current and Future version of scans i.e. from v1.0 is taking high resolution of image for which algorithm takes lot of time to process in comparison to older version of scans.

So while performing the face blur resizing the height of the image to 500 and adjusting the width of the image by keeping the same aspect ratio as original image. This will reduce the time to perform face blur.