### PR TITLE
orient and reorient images

### DIFF
--- a/src/result_generation/blur.py
+++ b/src/result_generation/blur.py
@@ -11,17 +11,6 @@ import log
 
 logger = log.setup_custom_logger(__name__)
 
-# resize_factor_for_scan_version = {
-#     "v0.1": 3,
-#     "v0.2": 3,
-#     "v0.4": 3,
-#     "v0.5": 3,
-#     "v0.6": 3,
-#     "v0.7": 4,
-#     "v0.8": 1,
-#     "v0.9": 1,
-#     "v1.0": 1,
-# }
 
 standing_scan_type = ["101", "102", "103"]
 laying_scan_type = ["201", "202", "203"]
@@ -38,7 +27,7 @@ class BlurFlow:
             artifacts,
             scan_version,
             scan_type):
-        store_attr('result_generation,artifacts,workflow_path,workflow_faces_path,artifacts,scan_version,scan_type', self)
+        store_attr('result_generation,workflow_path,workflow_faces_path,artifacts,scan_version,scan_type', self)
         self.workflow_obj = self.result_generation.workflows.load_workflows(self.workflow_path)
         self.workflow_faces_obj = self.result_generation.workflows.load_workflows(self.workflow_faces_path)
         if self.workflow_obj["data"]["input_format"] == 'image/jpeg':
@@ -52,8 +41,6 @@ class BlurFlow:
             self.workflow_obj['name'], self.workflow_obj['version'])
         self.workflow_faces_obj['id'] = self.result_generation.workflows.get_workflow_id(
             self.workflow_faces_obj['name'], self.workflow_faces_obj['version'])
-
-        self.scan_version = scan_version
 
     def run_flow(self):
         """Driver method for blur flow"""
@@ -72,16 +59,24 @@ class BlurFlow:
                 artifact['blurred_image'] = blur_img_binary
                 artifact['faces_detected'] = faces_detected
 
-    # def blur_set_resize_factor(self):
-    #     if self.scan_version in resize_factor_for_scan_version:
-    #         self.resize_factor = resize_factor_for_scan_version[self.scan_version]
-    #     else:
-    #         # Default Resize factor to 1
-    #         logger.info("New Scan Version Type")
-    #         self.resize_factor = 1
+    def orient_img(self, image):
+        # The images are rotated 90 degree clockwise for standing children
+        # and 90 degree anticlock wise for laying children to make children
+        # head at top and toe at bottom
+        if self.scan_type in standing_scan_type:
+            image = cv2.rotate(image, cv2.ROTATE_90_CLOCKWISE)
+        elif self.scan_type in laying_scan_type:
+            image = cv2.rotate(image, cv2.ROTATE_90_COUNTERCLOCKWISE)
 
-    #     logger.info("%s %s", "resize_factor is", self.resize_factor)
-    #     logger.info("%s %s", "scan_version is", self.scan_version)
+        return image
+
+    def reorient_back(self, image):
+        if self.scan_type in standing_scan_type:
+            image = cv2.rotate(image, cv2.ROTATE_90_COUNTERCLOCKWISE)
+        elif self.scan_type in laying_scan_type:
+            image = cv2.rotate(image, cv2.ROTATE_90_CLOCKWISE)
+
+        return image
 
     def blur_img_transformation_using_scan_version_and_scan_type(self, rgb_image):
         if self.scan_version in ["v0.7"]:
@@ -93,15 +88,6 @@ class BlurFlow:
         # print("scan_version is ", self.scan_version)
         image = rgb_image[:, :, ::-1]  # RGB -> BGR for OpenCV
 
-        # if self.scan_version in ["v0.1", "v0.2", "v0.4", "v0.5", "v0.6", "v0.7", "v0.8", "v0.9", "v1.0"]:
-        # The images are provided in 90degrees turned. Here we rotate 90degress to
-        # the right.
-        if self.scan_type in standing_scan_type:
-            image = cv2.rotate(image, cv2.ROTATE_90_CLOCKWISE)
-        elif self.scan_type in laying_scan_type:
-            image = cv2.rotate(image, cv2.ROTATE_90_COUNTERCLOCKWISE)
-
-        logger.info("%s %s", "scan_version is", self.scan_version)
         logger.info("swapped image axis")
         return image
 
@@ -116,6 +102,8 @@ class BlurFlow:
         rgb_image = cv2.imread(str(source_path))
 
         image = self.blur_img_transformation_using_scan_version_and_scan_type(rgb_image)
+        image = self.orient_img(image)
+
         height, width, channels = image.shape
 
         resized_height = 500.0
@@ -124,15 +112,11 @@ class BlurFlow:
         # resized_height, resized_width = int(resized_height), int(resized_width)
 
         # Scale image down for faster prediction.
-        # small_image = cv2.resize(
-        #     image, (0, 0), fx=1.0 / self.resize_factor, fy=1.0 / self.resize_factor)
-
         small_image = cv2.resize(
             image, (0, 0), fx=1.0 / resize_factor, fy=1.0 / resize_factor)
 
         # Find face locations.
         face_locations = face_recognition.face_locations(small_image, model="cnn")
-
         faces_detected = len(face_locations)
 
         # Blur the image.
@@ -155,9 +139,7 @@ class BlurFlow:
             # Put the blurred face region back into the frame image.
             image[top:bottom, left:right] = face_image
 
-        # if self.scan_version in ["v0.2", "v0.4", "v0.6", "v0.7", "v0.8"]:
-        #    # Rotate image back.
-        #    image = np.swapaxes(image, 0, 1)
+        image = self.reorient_back(image)
 
         # Write image to hard drive.
         rgb_image = image[:, :, ::-1]  # BGR -> RGB for OpenCV

--- a/src/workflows/blur-faces-worklows.json
+++ b/src/workflows/blur-faces-worklows.json
@@ -1,6 +1,6 @@
 {
     "name": "face_detection",
-    "version": "1.0.0",
+    "version": "1.0.3",
     "result_format": "dict",
     "result_binding": "artifact",
     "data":{

--- a/src/workflows/blur-workflow.json
+++ b/src/workflows/blur-workflow.json
@@ -1,6 +1,6 @@
 {
     "name": "face_recognition",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "result_format": "img",
     "result_binding": "artifact",
     "data":{


### PR DESCRIPTION
Motivation: RGB images is having different orientation of standing and laying children. 

Component Requirements 1880: [Turn RGB image back in cgm-rg face blurring workflow](https://dev.azure.com/cgmorg/ChildGrowthMonitor/_workitems/edit/1880)
We need to orient it in posture such that child head is at top of image and toe is at bottom of image. This lead to better performance in face blur accuracy.

This PR orients and performs face blur and reorients to its original orientation of RGB image.