### PR TITLE
Added support for calibration file

### DIFF
--- a/src/prepare_artifacts.py
+++ b/src/prepare_artifacts.py
@@ -53,8 +53,11 @@ class PrepareArtifacts:
             return 'img'
         elif format in ['application/zip', 'depth']:
             return 'depth'
+        elif format in ['calibration']:
+            return 'calibration'
         else:
-            raise NameError(f"Unknown format {format}")
+            logger.warning(f"Unknown format {format}")
+            # raise NameError(f"Unknown format {format}")
 
     def add_artifacts_to_format_dictionary(self, format, artifact):
         """Sort artifacts according to input format"""


### PR DESCRIPTION
Bug: [1780: Laying children orientation Fix](https://dev.azure.com/cgmorg/ChildGrowthMonitor/_workitems/edit/1780) 
While fixing orientation issue, Encountered another bug.
NameError: Unknown format calibration

As calibration file was added as a part of scan in later version, so This PR adds support for calibration file in a scan.