### PR TITLE
Ignore matching of height artifact level workflow for retroactive

### DIFF
--- a/src/result_gen_with_api.py
+++ b/src/result_gen_with_api.py
@@ -193,6 +193,11 @@ def run_retroactive_flow():
         workflow_id = scan_metadata_with_workflow_obj['workflow_id']
         logger.info("%s %s", "Workflow ID :", workflow_id)
 
+        # Match workflow with height artifact level workflow and skip data download and preprocessing
+        if workflow.match_workflows(height_workflow_artifact_path, workflow_id) or workflow.match_workflows(height_rgbd_workflow_artifact_path, workflow_id):
+            queue_service.delete_message(queue_name, message.id, message.pop_receipt)
+            continue
+
         data_processing = PrepareArtifacts(cgm_api, scan_metadata, retroactive_scan_dir)
         data_processing.process_scan_metadata()
         data_processing.create_scan_dir()


### PR DESCRIPTION
Motivation: Skip the data download and preprocessing for height artifact level workflow