### PR TITLE
Fix: Wrong /app dir

### DIFF
--- a/src/result_gen_with_api.py
+++ b/src/result_gen_with_api.py
@@ -22,7 +22,7 @@ from result_generation.standing import StandingLaying
 logger = log.setup_custom_logger(__name__)
 
 
-REPO_DIR = Path(os.environ['PWD']).absolute()
+REPO_DIR = Path(os.getenv('APP_DIR', '/app'))
 
 
 def person(api, person_id):

--- a/src/result_generation/height/height_ensemble.py
+++ b/src/result_generation/height/height_ensemble.py
@@ -16,7 +16,7 @@ import log
 
 logger = log.setup_custom_logger(__name__)
 
-REPO_DIR = Path(os.environ['PWD']).absolute()
+REPO_DIR = Path(os.getenv('APP_DIR', '/app'))
 
 
 class HeightFlowDeepEnsemble(HeightFlow):

--- a/src/result_generation/pose_prediction/inference.py
+++ b/src/result_generation/pose_prediction/inference.py
@@ -23,7 +23,7 @@ import log
 
 logger = log.setup_custom_logger(__name__)
 
-REPO_DIR = Path(os.environ['PWD']).absolute()
+REPO_DIR = Path(os.getenv('APP_DIR', '/app'))
 
 
 class PosePrediction:

--- a/src/utils/inference.py
+++ b/src/utils/inference.py
@@ -16,7 +16,7 @@ sys.path.append(
 current_working_directory = Path.cwd()
 models_path = current_working_directory.joinpath('models')
 
-REPO_DIR = Path(os.environ['PWD']).absolute()
+REPO_DIR = Path(os.getenv('APP_DIR', '/app'))
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "4"
 
 # TODO generate the config file


### PR DESCRIPTION
**Problem**: https://github.com/Welthungerhilfe/cgm-rg/pull/143/files introduced a global variable `REPO_DIR`. This was set to PWD, but in the deployed version `PWD` evaluates to `/root` (probably because the script is started while in the `/root` dir), but should instead be `/app`. 

**Solution**: Use optional environment variable `APP_DIR` to configure the `/app` dir.