### PR TITLE
Fix height model

### DIFF
--- a/src/download_model.py
+++ b/src/download_model.py
@@ -82,7 +82,7 @@ def main():
     # Download model for height
     download_model(ws=ws,
                    experiment_name='q4-depthmap-plaincnn-height-264k',
-                   run_id='q4-depthmap-plaincnn-height-264k_1632249604_5eb2be91',
+                   run_id='q4-depthmap-plaincnn-height-264k_1631047085_7bc153d2',
                    input_location=os.path.join('outputs', 'best_model.ckpt'),
                    output_location=REPO_DIR / 'models/height')
 

--- a/src/workflows/height-plaincnn-workflow-artifact.json
+++ b/src/workflows/height-plaincnn-workflow-artifact.json
@@ -1,6 +1,6 @@
 {
     "name": "q4-depthmap-plaincnn-height",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "result_format": "dict",
     "result_binding": "artifact",
     "data": {

--- a/src/workflows/height-plaincnn-workflow-scan.json
+++ b/src/workflows/height-plaincnn-workflow-scan.json
@@ -1,6 +1,6 @@
 {
     "name": "q4-depthmap-plaincnn-height-mean",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "result_format": "dict",
     "result_binding": "scan",
     "data": {


### PR DESCRIPTION
Motivation: Q4-depthmap mean height model is not working properly.
Fixes:

- Updated height model run id
- Updated workflow version to produce new results