### PR TITLE
Revert refactoring changes with new height model

### DIFF
--- a/src/download_model.py
+++ b/src/download_model.py
@@ -79,10 +79,10 @@ def main():
     download_model_from_registered_model(
         workspace=ws, model_name='standing_laying_classifier', output_location=REPO_DIR / 'models')
 
-    # Download model for height
+    # Download model for depthmap height
     download_model(ws=ws,
                    experiment_name='q4-depthmap-plaincnn-height-264k',
-                   run_id='q4-depthmap-plaincnn-height-264k_1632249604_5eb2be91',
+                   run_id='q4-depthmap-plaincnn-height-264k_1631047085_7bc153d2',
                    input_location=os.path.join('outputs', 'best_model.ckpt'),
                    output_location=REPO_DIR / 'models/height')
 

--- a/src/workflows/height-plaincnn-workflow-artifact.json
+++ b/src/workflows/height-plaincnn-workflow-artifact.json
@@ -1,6 +1,6 @@
 {
     "name": "q4-depthmap-plaincnn-height",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "result_format": "dict",
     "result_binding": "artifact",
     "data": {

--- a/src/workflows/height-plaincnn-workflow-scan.json
+++ b/src/workflows/height-plaincnn-workflow-scan.json
@@ -1,6 +1,6 @@
 {
     "name": "q4-depthmap-plaincnn-height-mean",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "result_format": "dict",
     "result_binding": "scan",
     "data": {


### PR DESCRIPTION
Motivation: Q4-depthmap mean height model is not working properly.
Fixes:

- Reverting the refactoring done by MH due to some bug while refacoring.
- Updated height model run id
- Updated workflow version to produce new results