### PR TITLE
fix default value for scan_parent_dir

### DIFF
--- a/src/result_gen_with_api.py
+++ b/src/result_gen_with_api.py
@@ -32,7 +32,7 @@ def person(api, person_id):
 def parse_args():
     parser = argparse.ArgumentParser()
     workflow_dir = str(REPO_DIR / 'src/workflows')
-    parser.add_argument('--scan_parent_dir', default="data/scans/", help='Parent directory in which scans will be stored')  # noqa: E501
+    parser.add_argument('--scan_parent_dir', default=f"{REPO_DIR}/data/scans/", help='Parent directory in which scans will be stored')  # noqa: E501
     parser.add_argument('--pose_workflow_path', default=f"{workflow_dir}/pose_prediction-workflow.json")  # noqa: E501
     parser.add_argument('--pose_visualization_workflow_path', default=f"{workflow_dir}/pose-visualize-workflows.json")  # noqa: E501
     parser.add_argument('--blur_faces_workflow_path', default=f"{workflow_dir}/blur-faces-worklows.json")  # noqa: E501


### PR DESCRIPTION
- fix [20:13] Nikhil Gupta
Markus Hinsche Why we are getting below error in sandbox? Could you take a look.2021-11-10 14:41:11,706 - INFO - App URL: https://cgm-be-ci-dev-scanner-api.azurewebsites.net - /app/src/result_gen_with_api.py: line69
SavedModel file does not exist at: /app/app/models/height_rgbd/best_model.ckpt/{saved_model.pbtxt|saved_model.pb}
Not able to load the rgbd model
Traceback (most recent call last):
File "/app/src/result_gen_with_api.py", line 296, in <module>
main()
File "/app/src/result_gen_with_api.py", line 291, in main
run_normal_flow()
File "/app/src/result_gen_with_api.py", line 75, in run_normal_flow
if get_scan_metadata.get_unprocessed_scans() <= 0:
File "/app/src/get_scan_metadata.py", line 25, in get_unprocessed_scans
return self.api.get_scan(self.scan_metadata_path)
File "/app/src/api_endpoints.py", line 143, in get_scan
with open(scan_path, 'w') as f:
FileNotFoundError: [Errno 2] No such file or directory: 'data/scans/scan_meta_852944c9-70bc-493c-9731-002196e6628e.json'

using default variable which are not set right