### PR TITLE
downgrade azure-devops extension to 0.25.0

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -223,6 +223,15 @@ stages:
                   - bash: pip install azure-cli==2.29.2
                     displayName: 'Downgrade Azure CLI to 2.29.2'
                   - task: AzureCLI@2
+                    displayName: Downgrade azure-devops extension to 0.25.0
+                    inputs:
+                      azureSubscription: cgm-${{ env }}-sub-cd
+                      scriptType: bash
+                      scriptLocation: inlineScript
+                      inlineScript: |
+                        az extension remove --name azure-devops
+                        az extension add --name azure-devops --version 0.25.0
+                  - task: AzureCLI@2
                     displayName: Update Container Instance
                     inputs:
                       azureSubscription: cgm-${{ env }}-sub-cd


### PR DESCRIPTION
According to the error message from last pipeline deployment, it seems to be an version issue, since the az cli azure-devops extension got a version update (to 0.26.0), which seems not to be compatible with the already existing downgraded azure-cli (2.29.2) and needs at least azure-cli 2.30.

therefor a new task was added, which removes the current azure-devops extension, and installs the older "0.25.0" version.

Changes:
* got into the issue using azure devops pipeline log
* got overview about used versions of extensions
* added a new task to downgrade the azure-devops extension, right after the downgrade azure-cli task

Please consider:
regarding future readiness, the dependencies should be updated to newer versions. this fix is only a fix and not an improvement.